### PR TITLE
Simplify overview refresh coroutine handling

### DIFF
--- a/app/src/main/java/com/github/maximilianschwaerzler/ethuzhmensa/data/viewmodel/OverviewScreenViewModel.kt
+++ b/app/src/main/java/com/github/maximilianschwaerzler/ethuzhmensa/data/viewmodel/OverviewScreenViewModel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -60,7 +61,7 @@ class OverviewScreenViewModel @Inject constructor(
         .onStart {
             _isInitialLoading.value = true
             Log.d("OverviewScreenViewModel", "Initial loading start")
-            refreshData().join()
+            refreshData()
             Log.d("OverviewScreenViewModel", "Initial loading end")
             _isInitialLoading.value = false
         }
@@ -70,7 +71,7 @@ class OverviewScreenViewModel @Inject constructor(
      * Handles the pull-to-refresh action by refreshing the data and updating the loading state.
      * A delay is added to ensure the pull-to-refresh indicator is visible for a short duration.
      */
-    fun onPullToRefresh() = viewModelScope.launch(Dispatchers.IO) {
+    fun onPullToRefresh() = viewModelScope.launch {
         _isLoading.value = true
         refreshData()
         // Workaround for the pull to refresh indicator getting stuck
@@ -82,29 +83,28 @@ class OverviewScreenViewModel @Inject constructor(
      * Refreshes the facility and offer data by fetching from the respective repositories.
      * This function runs in the IO dispatcher and handles exceptions gracefully, logging any issues encountered.
      */
-    private fun refreshData() =
-        viewModelScope.launch(Dispatchers.IO) {
-            try {
-                supervisorScope {
-                    val facilityJob = launch {
-                        try {
-                            facilities.emit(facilityInfoRepo.getAllFacilities())
-                        } catch (e: IllegalStateException) {
-                            Log.d("OverviewScreenViewModel", "No internet connection", e)
-                        }
+    private suspend fun refreshData() = withContext(Dispatchers.IO) {
+        try {
+            supervisorScope {
+                val facilityJob = launch {
+                    try {
+                        facilities.emit(facilityInfoRepo.getAllFacilities())
+                    } catch (e: IllegalStateException) {
+                        Log.d("OverviewScreenViewModel", "No internet connection", e)
                     }
-                    val offerJob = launch {
-                        try {
-                            offers.emit(menuRepository.getOffersForDate(LocalDate.now()))
-                        } catch (e: IllegalStateException) {
-                            Log.w("OverviewScreenViewModel", "No internet connection", e)
-                        }
-                    }
-                    facilityJob.join()
-                    offerJob.join()
                 }
-            } catch (e: Exception) {
-                Log.w("OverviewScreenViewModel", "Unexpected error", e)
+                val offerJob = launch {
+                    try {
+                        offers.emit(menuRepository.getOffersForDate(LocalDate.now()))
+                    } catch (e: IllegalStateException) {
+                        Log.w("OverviewScreenViewModel", "No internet connection", e)
+                    }
+                }
+                facilityJob.join()
+                offerJob.join()
             }
+        } catch (e: Exception) {
+            Log.w("OverviewScreenViewModel", "Unexpected error", e)
         }
+    }
 }


### PR DESCRIPTION
## Summary
- make the overview refresh routine suspendable instead of launching nested coroutines
- simplify initial load and pull-to-refresh flows by directly awaiting the refresh work

## Testing
- bash ./gradlew test *(fails: proxy prevents downloading Gradle distribution)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935f687edec8328807eabfe3cc3ee8f)